### PR TITLE
Fix hash tree creation and stage2 logging

### DIFF
--- a/pipeline_dev/test_pefile.py
+++ b/pipeline_dev/test_pefile.py
@@ -17,7 +17,7 @@ def pefile_test(file_path):
     """
 
     # Parse the PE header
-    pe = pefile.PE(filename)
+    pe = pefile.PE(file_path)
 
     print("[*] Listing imported functions:")
     if hasattr(pe, 'DIRECTORY_ENTRY_IMPORT'):

--- a/src/nordstream/config.py
+++ b/src/nordstream/config.py
@@ -125,13 +125,21 @@ class HashValidator:
 
 
 def init_sample_tree() -> dict:
+    """Generate a dictionary with empty hash trees using the same keys as
+    used inside the :class:`Sample` dataclass.
+
+    Previously this function returned keys ``stage1``, ``stage2`` and
+    ``stage3``.  The :class:`Sample` dataclass however expects keys named
+    ``stage1_hashes`` etc.  This mismatch resulted in code adding new keys
+    on the fly (e.g. ``sample_tree["stage1_hashes"]``) leaving the original
+    unused entries behind.  Returning the correct keys ensures consistent
+    behaviour across the pipeline.
     """
-        Generate a dictionary with empty hash trees.
-        """
+
     return {
-        "stage1": HashTree(),
-        "stage2": HashTree(),
-        "stage3": HashTree()
+        "stage1_hashes": HashTree(),
+        "stage2_hashes": HashTree(),
+        "stage3_hashes": HashTree(),
     }
 
 

--- a/src/nordstream/stage2/stage2_run.py
+++ b/src/nordstream/stage2/stage2_run.py
@@ -6,8 +6,10 @@ from .string_extractor import StringExtractor
 from .header_analyzer import HeaderSectionAnalyzer
 
 def run(self, sample):
-    with self.logger.context({"sample_id": sample.id}):
-        self.logger.info(f"Processing sample id: {sample.id}")
+    # `Sample` objects expose the identifier as ``uuid``.  Using ``id``
+    # would raise an :class:`AttributeError` and stop the pipeline.
+    with self.logger.context({"sample_id": sample.uuid}):
+        self.logger.info(f"Processing sample id: {sample.uuid}")
 
         tasks = {
             "strings": StringExtractor(),
@@ -42,5 +44,7 @@ def run(self, sample):
         sample.opcodes = results["opcodes"]
         sample.entropy = results["entropy"]
 
-        self.logger.info(f"Completed processing for sample id: {sample.id}")
-        sample.hashes["stage2"] = calculate_file_hashes(2, sample.file_path)
+        self.logger.info(f"Completed processing for sample id: {sample.uuid}")
+        # store the newly calculated hashes in the expected ``stage2_hashes``
+        # entry of the sample
+        sample.hashes["stage2_hashes"] = calculate_file_hashes(2, sample.file_path)


### PR DESCRIPTION
## Summary
- normalize keys returned by `init_sample_tree`
- use `sample.uuid` in stage2 logger and store hashes in `stage2_hashes`
- fix typo in `pipeline_dev/test_pefile.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'lief')*

------
https://chatgpt.com/codex/tasks/task_e_6842e08484a4832284e2e87616cae2e7