### PR TITLE
Fix nordstream typo in stage1

### DIFF
--- a/src/nordstream/stage1/stage1.py
+++ b/src/nordstream/stage1/stage1.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 """
-Script Name: nordsream/stage1/stage1.py
+Script Name: nordstream/stage1/stage1.py
 Author: Hendrik Siemens
 Date Created: 2025-03-21
 Last Modified: 2025-03-23
@@ -15,7 +15,7 @@ Description:
     to a JSON file.
 
 Usage:
-    python3 nordsream/stage1/stage1.py [options]
+    python3 nordstream/stage1/stage1.py [options]
 
 Requirements:
     - Python >= 3.6


### PR DESCRIPTION
## Summary
- correct the project name in the stage1 docstring
- audit repository for further occurrences of the typo

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'binwalk.core')*

------
https://chatgpt.com/codex/tasks/task_e_6842e176fe88832289f16fe3e5e3dd57